### PR TITLE
React 16 compatibility

### DIFF
--- a/lib/feform.js
+++ b/lib/feform.js
@@ -13,6 +13,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _validate = require('validate.js');
 
 var _validate2 = _interopRequireDefault(_validate);
@@ -44,8 +48,8 @@ var iterateInputRefs = function iterateInputRefs(refs, fn) {
 };
 
 var findInputs = function findInputs(children, valueChange) {
-    var context = arguments.length <= 2 || arguments[2] === undefined ? { inputIndex: 0, childIndex: 0 } : arguments[2];
-    var depth = arguments.length <= 3 || arguments[3] === undefined ? 0 : arguments[3];
+    var context = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : { inputIndex: 0, childIndex: 0 };
+    var depth = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 0;
 
     var inputs = [];
     _react2.default.Children.forEach(children, function (child) {
@@ -80,7 +84,7 @@ var findInputs = function findInputs(children, valueChange) {
 };
 
 var runValidations = function runValidations(inputs) {
-    var reportFailures = arguments.length <= 1 || arguments[1] === undefined ? true : arguments[1];
+    var reportFailures = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
 
     var allFailures = [],
         inputCount = 0,
@@ -134,7 +138,7 @@ var Form = function (_Component) {
     _inherits(Form, _Component);
 
     function Form() {
-        var _Object$getPrototypeO;
+        var _ref;
 
         var _temp, _this2, _ret;
 
@@ -144,7 +148,7 @@ var Form = function (_Component) {
             args[_key] = arguments[_key];
         }
 
-        return _ret = (_temp = (_this2 = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Form)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this2), _this2.state = {
+        return _ret = (_temp = (_this2 = _possibleConstructorReturn(this, (_ref = Form.__proto__ || Object.getPrototypeOf(Form)).call.apply(_ref, [this].concat(args))), _this2), _this2.state = {
             validationFailures: []
         }, _this2.getInputByName = function (name) {
             var input = void 0;
@@ -186,7 +190,7 @@ var Form = function (_Component) {
                 validationFailures: []
             }, me.props.afterReset);
         }, _this2.validate = function () {
-            var reportInputErrors = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+            var reportInputErrors = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
 
             var me = _this2;
 
@@ -201,15 +205,14 @@ var Form = function (_Component) {
     _createClass(Form, [{
         key: 'render',
         value: function render() {
-            var me = this;
-            var _me$props = me.props;
-            var submit = _me$props.submit;
-            var validityChange = _me$props.validityChange;
-            var afterReset = _me$props.afterReset;
-            var reportFieldErrors = _me$props.reportFieldErrors;
-            var children = _me$props.children;
-
-            var rest = _objectWithoutProperties(_me$props, ['submit', 'validityChange', 'afterReset', 'reportFieldErrors', 'children']);
+            var me = this,
+                _me$props = me.props,
+                submit = _me$props.submit,
+                validityChange = _me$props.validityChange,
+                afterReset = _me$props.afterReset,
+                reportFieldErrors = _me$props.reportFieldErrors,
+                children = _me$props.children,
+                rest = _objectWithoutProperties(_me$props, ['submit', 'validityChange', 'afterReset', 'reportFieldErrors', 'children']);
             /* eslint-disable */
 
             return _react2.default.createElement(
@@ -226,10 +229,10 @@ var Form = function (_Component) {
 }(_react.Component);
 
 Form.propTypes = {
-    submit: _react.PropTypes.func,
-    validityChange: _react.PropTypes.func,
-    afterReset: _react.PropTypes.func,
-    reportFieldErrors: _react.PropTypes.bool
+    submit: _propTypes2.default.func,
+    validityChange: _propTypes2.default.func,
+    afterReset: _propTypes2.default.func,
+    reportFieldErrors: _propTypes2.default.bool
 };
 Form.defaultProps = {
     submit: Function.prototype,
@@ -249,7 +252,7 @@ var feinput = function feinput(ComposedComponent) {
         function _class(props) {
             _classCallCheck(this, _class);
 
-            var _this3 = _possibleConstructorReturn(this, Object.getPrototypeOf(_class).call(this, props));
+            var _this3 = _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).call(this, props));
 
             _this3.setErrors = function (errors) {
                 _this3.setState({
@@ -272,7 +275,7 @@ var feinput = function feinput(ComposedComponent) {
             };
 
             _this3.setValue = function (value) {
-                var clearErrors = arguments.length <= 1 || arguments[1] === undefined ? false : arguments[1];
+                var clearErrors = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
 
                 var nextState = { value: value };
 
@@ -330,9 +333,9 @@ var feinput = function feinput(ComposedComponent) {
 
         return _class;
     }(_react2.default.Component), _class.displayName = 'feinput', _class.propTypes = {
-        name: _react.PropTypes.string.isRequired,
-        validations: _react.PropTypes.array,
-        initialValue: _react.PropTypes.string
+        name: _propTypes2.default.string.isRequired,
+        validations: _propTypes2.default.array,
+        initialValue: _propTypes2.default.string
     }, _class.defaultProps = {
         validations: [],
         initialValue: ''
@@ -342,15 +345,14 @@ var feinput = function feinput(ComposedComponent) {
 // utility function to pass allowed props to native input elements, preventing invalid prop warning (React 15.2+)
 var inputPropSanitizer = function inputPropSanitizer(props) {
     /* eslint-disable */
-    var name = props.name;
-    var validations = props.validations;
-    var initialValue = props.initialValue;
-    var errors = props.errors;
-    var setValue = props.setValue;
-    var clearValue = props.clearValue;
-    var valueChange = props.valueChange;
-
-    var nativeProps = _objectWithoutProperties(props, ['name', 'validations', 'initialValue', 'errors', 'setValue', 'clearValue', 'valueChange']);
+    var name = props.name,
+        validations = props.validations,
+        initialValue = props.initialValue,
+        errors = props.errors,
+        setValue = props.setValue,
+        clearValue = props.clearValue,
+        valueChange = props.valueChange,
+        nativeProps = _objectWithoutProperties(props, ['name', 'validations', 'initialValue', 'errors', 'setValue', 'clearValue', 'valueChange']);
     /* eslint-disable */
 
     return nativeProps;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "json-loader": "0.5.4",
     "opn": "4.0.2",
     "postcss-loader": "0.9.1",
+    "react-dom": "^16.1.1",
     "rimraf": "2.5.3",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",
@@ -58,9 +59,12 @@
   },
   "dependencies": {
     "lodash": "^4.13.1",
-    "react": "^15.2.1",
-    "react-dom": "^15.2.1",
+    "prop-types": "^15.6.0",
     "validate.js": "^0.10.0"
+  },
+  "peerDependencies": {
+    "react": "^15.2.1",
+    "react-dom": "^15.2.1"
   },
   "scripts": {
     "prepublish": "node_modules/babel-cli/bin/babel.js src/feform.js --out-file lib/feform.js",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "json-loader": "0.5.4",
     "opn": "4.0.2",
     "postcss-loader": "0.9.1",
+    "react": "^16.1.1",
     "react-dom": "^16.1.1",
     "rimraf": "2.5.3",
     "style-loader": "0.13.1",

--- a/src/examples/Demo.js
+++ b/src/examples/Demo.js
@@ -266,11 +266,11 @@ class Example7 extends Component {
     };
 
     handleExternalSubmit = () => {
-        this.refs.form.submit();
+        this.form.submit();
     };
 
     handleExternalReset = () => {
-        this.refs.form.reset();
+        this.form.reset();
     };
 
     render() {
@@ -280,7 +280,7 @@ class Example7 extends Component {
             <div>
                 <div style={{display: 'inline-block', width: 400, float: 'left'}}>
                     <h2>External Submit</h2>
-                    <Form ref="form" submit={(event) => {
+                    <Form ref={c => { this.form = c; }} submit={(event) => {
                         props.handleSubmit(event, 'Example 7')
                     }}>
                         <Field name="username" label="Username" validations={['required']}/>
@@ -302,7 +302,7 @@ class Example8 extends Component {
             <div>
                 <div style={{display: 'inline-block', width: 400, float: 'left'}}>
                     <h2>Multi Value Input</h2>
-                    <Form ref="form" submit={(event) => {
+                    <Form submit={(event) => {
                         props.handleSubmit(event, 'Example 8')
                     }}>
                         <MultiValueInput name="favoriteLetter" label="Favorite Letter"

--- a/src/examples/Inputs.js
+++ b/src/examples/Inputs.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {feinput, inputPropSanitizer} from '../feform';
 import _ from 'lodash';
 

--- a/src/feform.js
+++ b/src/feform.js
@@ -3,15 +3,7 @@ import PropTypes from 'prop-types';
 import Validate from 'validate.js';
 import _ from 'lodash';
 
-const iterateInputRefs = function(refs, fn) {
-    _.forOwn(refs, (value, key) => {
-        if (key.startsWith('input')) {
-            fn.call(this, value);
-        }
-    });
-};
-
-const findInputs = function(children, valueChange, context={inputIndex: 0, childIndex: 0}, depth=0) {
+const findInputs = function(form, children, valueChange, context={inputIndex: 0, childIndex: 0}, depth=0) {
     let inputs = [];
     React.Children.forEach(children, (child) => {
         // have to assign a key to avoid warning about dynamic children
@@ -23,14 +15,14 @@ const findInputs = function(children, valueChange, context={inputIndex: 0, child
         }
         if (child && child.type && child.type.displayName === 'feinput') {
             let input = React.cloneElement(child, {
-                ref: `input${context.inputIndex++}`,
+                ref: c => { form.inputs[context.inputIndex++] = c; },
                 key: childKey,
                 valueChange
             });
             inputs.push(input);
         } else {
           if (child && child.props && child.props.children) {
-              let childInputs = findInputs(child.props.children, valueChange, context, depth+1);
+              let childInputs = findInputs(form, child.props.children, valueChange, context, depth+1);
               let input = React.cloneElement(child, {
                 key: childKey,
                 ...child.props
@@ -51,7 +43,9 @@ const runValidations = function(inputs, reportFailures = true) {
         pristineCount = 0,
         data = {};
 
-    iterateInputRefs.call(this, inputs, function(input) {
+    _.forEach(inputs, input => {
+        if (!input) return;
+
         let inputFailures = [];
             inputCount++;
 
@@ -113,10 +107,12 @@ export default class Form extends Component {
         validationFailures: []
     };
 
+    inputs = [];
+
     getInputByName = (name) => {
         let input;
 
-        _.forOwn(this.refs, (ref) => {
+        _.forOwn(this.inputs, (ref) => {
             if (ref.getName && ref.getName() === name) {
                 input = ref;
             }
@@ -132,14 +128,15 @@ export default class Form extends Component {
             changedData = {},
             me = this;
 
-        iterateInputRefs.call(me, me.refs, function(input) {
+        _.forEach(me.inputs, function(input) {
+            if (!input) return;
             data[input.getName()] = input.getValue();
             if (!input.isPristine()) {
                 changedData[input.getName()] = input.getValue();
             }
         });
 
-        const validate = runValidations(me.refs, true);
+        const validate = runValidations(me.inputs, true);
 
         me.props.submit(Object.assign({}, validate, {data, changedData}), true);
     };
@@ -149,7 +146,8 @@ export default class Form extends Component {
 
         event.preventDefault();
 
-        iterateInputRefs.call(me, me.refs, function(input) {
+        _.forEach(me.inputs, function(input) {
+            if (!input) return;
             input.resetValue();
         });
 
@@ -161,15 +159,15 @@ export default class Form extends Component {
     validate = (reportInputErrors = true) => {
         const me = this;
 
-        return runValidations(me.refs, reportInputErrors);
+        return runValidations(me.inputs, reportInputErrors);
     };
 
     submit = () => {
-        this.refs.form.dispatchEvent(new Event('submit'));
+        this.form.dispatchEvent(new Event('submit'));
     };
 
     reset = () => {
-        this.refs.form.dispatchEvent(new Event('reset'));
+        this.form.dispatchEvent(new Event('reset'));
     };
 
     render() {
@@ -180,9 +178,9 @@ export default class Form extends Component {
             /* eslint-disable */
 
         return (
-            <form ref="form" {...rest} onSubmit={me.handleSubmit} onReset={me.handleReset} noValidate>
-                {findInputs(children, () => {
-                    me.props.validityChange(runValidations(me.refs, me.props.reportFieldErrors));
+            <form ref={(c) => this.form = c} {...rest} onSubmit={me.handleSubmit} onReset={me.handleReset} noValidate>
+                {findInputs(this, children, () => {
+                    me.props.validityChange(runValidations(me.inputs, me.props.reportFieldErrors));
                 })}
             </form>
         );

--- a/src/feform.js
+++ b/src/feform.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Validate from 'validate.js';
 import _ from 'lodash';
 


### PR DESCRIPTION
- import PropTypes from `prop-types` module
- install react with dev & peer dependencies
- get input refs through callbacks instead of prop names
